### PR TITLE
Added no_std attribute to prevent compile errors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@
 //! # fn main() {}
 //! const HELLO_WORLD_UTF16: &[u16] = const_utf16::encode!("Hello, world!");
 //! ```
+#![no_std]
 #![deny(missing_docs)]
 
 /// Encode a &str as a utf16 buffer.
@@ -170,22 +171,23 @@ const CONT_MASK: u8 = 0b0011_1111;
 #[cfg(test)]
 mod tests {
     use super::*;
+    use core::iter::once;
+
     #[test]
     fn encode_utf16_works() {
         const TEXT: &str = "Hello \0ä日本 語";
-        let expected = TEXT.encode_utf16().collect::<Vec<_>>();
+        let expected = TEXT.encode_utf16();
         const RESULT: &[u16] = encode!(TEXT);
 
-        assert_eq!(RESULT, &expected[..]);
+        assert!(RESULT.iter().cloned().eq(expected));
     }
 
     #[test]
     fn encode_utf16_with_null_byte_works() {
         const TEXT: &str = "Hello ä日本 語";
-        let result = TEXT.encode_utf16().collect::<Vec<_>>();
+        let expected = TEXT.encode_utf16().chain(once(0));
         const RESULT: &[u16] = encode_null_terminated!(TEXT);
 
-        assert_eq!(&RESULT[0..result.len()], &result[..]);
-        assert_eq!(&RESULT[result.len()..result.len() + 1], &[0]);
+        assert!(RESULT.iter().cloned().eq(expected));
     }
 }


### PR DESCRIPTION
This should fix the compilation error of no_std crates that depends on that macro. This error probably comes because panic handler included twice during compilation.

```rust
#[panic_handler]
fn panic(_: &core::panic::PanicInfo) -> ! {
    loop {}
}
```

```
error[E0152]: found duplicate lang item `panic_impl`
  --> src\main.rs:35:1
   |
35 | fn panic(_: &core::panic::PanicInfo) -> ! {
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: the lang item is first defined in crate `std` (which `const_utf16` depends on)
   = note: first definition in `std` loaded from \\?\C:\Users\alex\.rustup\toolchains\nightly-x86_64-pc-windows-msvc\lib\rustlib\x86_64-pc-windows-msvc\lib\std-09e4abccd169ee6e.dll, \\?\C:\Users\alex\.rustup\toolchains\nightly-x86_64-pc-windows-msvc\lib\rustlib\x86_64-pc-windows-msvc\lib\libstd-09e4abccd169ee6e.rlib
```